### PR TITLE
useAsync内で定義されているdoAsync,resetの依存関係を修正

### DIFF
--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -42,7 +42,7 @@ export const useAsync = <Arg, Result, Empty>(
           throw e
         })
     },
-    [fn, ready, busy],
+    [set, fn, emptyResult],
   )
   const reset = useCallback(
     () =>
@@ -52,7 +52,7 @@ export const useAsync = <Arg, Result, Empty>(
         result: emptyResult,
         error: null,
       }),
-    [],
+    [set, emptyResult],
   )
   return {
     ready,


### PR DESCRIPTION
`useAsync` の内部で `React.useCallback` で定義されている `doAsync` と `reset` の依存関係を修正しました。

これらの関数は [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) を使って検査すると警告が表示され、それぞれ次の通り修正するよう提案されます：

![image](https://user-images.githubusercontent.com/37999847/101603739-59475900-3a43-11eb-8d5e-9e6e60995eec.png)
![image](https://user-images.githubusercontent.com/37999847/101603745-5b111c80-3a43-11eb-90e6-32dbb2ac5243.png)

特に `doAsync` は、関数内で更新している `ready` と `busy` に依存するように書かれているため、ライブラリの利用者側で `doAsync` を依存関係として持つような副作用フックを書いた場合に無限ループが発生してしまっていました。

サンプル: https://codesandbox.io/s/staging-night-mxsos
（ブラウザの開発者ツールを開いてコンソールを見ると `"useEffect (useAsync)"` が出力され続けているのがわかる）